### PR TITLE
A fix to rendered video media type from NASA API

### DIFF
--- a/src/Components/Pod/index.js
+++ b/src/Components/Pod/index.js
@@ -16,7 +16,7 @@ import {
 
 const PodCard = (props) => {
   const {
-    data: { title, url, hdurl, explanation, date, copyright, mediaType },
+    data: { title, url, hdurl, explanation, date, copyright, media_type: mediaType },
     redirect,
   } = props;
 


### PR DESCRIPTION
This PR resolves an issue with the media type video from NASA API. 
As NASA API send randomize media type that fixes should allow videos to be rendered correctly. 