### PR TITLE
Added IndexedDB to enchance performance photos fetch

### DIFF
--- a/src/Components/MarsRovers/Rover/RoverCameras/ListOfPhotosByPage.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/ListOfPhotosByPage.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import PhotoItem from './PhotoItem';
+
+export default function ListOfPhotosByPage(
+  activePageNumber,
+  camera,
+  roverName,
+  numberOfPhotosPerPage,
+  photosInMemory
+) {
+  const firstPhotoIndexToDisplay = (activePageNumber - 1) * numberOfPhotosPerPage;
+  const lastPhotoIndexToDisplay = activePageNumber * numberOfPhotosPerPage;
+
+  const photosToDisplayInCurrentPage = (photosInMemory[roverName][camera] || []).slice(
+    firstPhotoIndexToDisplay,
+    lastPhotoIndexToDisplay
+  );
+
+  const listOfRoverPhotoItemsToDisplay = photosToDisplayInCurrentPage.map(
+    function makePhotoItemFromPhotoData(photo) {
+      return (
+        <PhotoItem
+          key={uuidv4()}
+          photoId={photo.id}
+          src={photo.img_src}
+          alt={
+            `Taken by rover ${roverName} from camera ${camera}` +
+            ` on earth date ${photo.earth_date}, which is the` +
+            ` martian sol number ${photo.sol} relative to the rover.`
+          }
+        />
+      );
+    }
+  );
+
+  return listOfRoverPhotoItemsToDisplay;
+}

--- a/src/Components/MarsRovers/Rover/RoverCameras/LoadImageAsBase64String.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/LoadImageAsBase64String.js
@@ -1,0 +1,32 @@
+const crossOriginByPass = 'https://cors-anywhere.herokuapp.com/';
+
+async function loadImg(src) {
+  const loader = new Promise(function imageLoader(resolve, reject) {
+    const img = document.createElement('img');
+    img.onload = function returnLoadedImage() {
+      resolve(img);
+    };
+    img.onerror = function imageLoaderErrorHandler() {
+      reject(new Error('Error while loading image.'));
+    };
+    img.crossOrigin = 'anonymous';
+    img.src = crossOriginByPass + src;
+  });
+  const loadedImage = await loader;
+  return loadedImage;
+}
+
+function convertImgToBase64String(image) {
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  canvas.getContext('2d').drawImage(image, 0, 0, image.width, image.height);
+  const imageAsBase64String = canvas.toDataURL();
+  return imageAsBase64String;
+}
+
+export default async function loadImageAsBase64String(src) {
+  const loadedImage = await loadImg(src);
+  const imageSrcInBase64 = convertImgToBase64String(loadedImage);
+  return imageSrcInBase64;
+}

--- a/src/Components/MarsRovers/Rover/RoverCameras/PhotoItem.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/PhotoItem.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { ImageWithHoverToFitGrid } from './styles';
+import PulsingThreeDots from './PulsingThreeDots';
+import { hasPhotoInDB, readPhotoFromDB, savePhotoToDB } from './PhotosDB';
+import loadImageAsBase64String from './LoadImageAsBase64String';
+
+export default function PhotoItem({ alt, photoId, src }) {
+  const [imageSrc, setImageSrc] = useState('');
+  const [isLoadingPhotoData, setIsLoadingPhotoData] = useState(true);
+  const [isComponentMounted, setIsComponentMounted] = useState(true);
+
+  useEffect(
+    function onComponentRender() {
+      setIsComponentMounted(true);
+      setIsLoadingPhotoData(true);
+      (async function synchronizeWithDatabase() {
+        try {
+          const hasCurrentPhotoInDB = await hasPhotoInDB(photoId);
+          if (hasCurrentPhotoInDB) {
+            const photoFromDB = await readPhotoFromDB(photoId);
+            if (isComponentMounted) {
+              setImageSrc(photoFromDB.srcInBase64);
+            }
+          } else {
+            const imageSrcInBase64 = await loadImageAsBase64String(src);
+            if (isComponentMounted) {
+              setImageSrc(imageSrcInBase64);
+            }
+            const photo = {
+              id: photoId,
+              srcInBase64: imageSrcInBase64,
+            };
+            await savePhotoToDB(photo);
+          }
+        } catch {
+          if (isComponentMounted) {
+            setImageSrc(src);
+          }
+        }
+      })();
+
+      return function onComponentUnmount() {
+        setIsComponentMounted(false);
+      };
+    },
+    [photoId, src, isComponentMounted]
+  );
+
+  return (
+    <>
+      {isLoadingPhotoData ? <PulsingThreeDots /> : null}
+      <ImageWithHoverToFitGrid
+        src={imageSrc}
+        alt={alt}
+        style={isLoadingPhotoData ? { display: 'none' } : null}
+        onLoad={() => {
+          if (isComponentMounted) setIsLoadingPhotoData(false);
+        }}
+      />
+    </>
+  );
+}

--- a/src/Components/MarsRovers/Rover/RoverCameras/PhotosDB.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/PhotosDB.js
@@ -1,0 +1,103 @@
+let db;
+const dbName = 'marsRoversPhotos';
+const dbVersion = 1;
+
+(function openIndexedDB() {
+  const openRequest = indexedDB.open(dbName, dbVersion);
+
+  openRequest.onsuccess = function openDBSuccessHandler() {
+    db = openRequest.result;
+
+    db.onversionchange = function commonVersionChangeHandler() {
+      db.close();
+      throw new Error('A new version of indexedDB is available, please reload the page.');
+    };
+
+    db.onerror = function databaseErrorHandler() {
+      throw new Error('Error on indexedDB.');
+    };
+  };
+
+  openRequest.onupgradeneeded = function openDBUpgradeHandler(event) {
+    const dbToUpdgrade = event.target.result;
+
+    dbToUpdgrade.createObjectStore('photos', { keyPath: 'id' });
+  };
+
+  openRequest.onerror = function openDBErrorHandler() {
+    throw new Error('Error on open operation of indexedDB.');
+  };
+
+  openRequest.onblocked = function openDBBlockHandler() {
+    throw new Error('Please close all other tabs of this website.');
+  };
+})();
+
+export async function savePhotoToDB(photo) {
+  const saveOperation = new Promise(function addPhotoToDB(resolve, reject) {
+    const transaction = db.transaction(['photos'], 'readwrite');
+
+    transaction.onerror = function writeTransactionErrorHandler() {
+      reject(new Error('Error on save transaction of indexedDB.'));
+    };
+
+    const saveRequest = transaction.objectStore('photos').add(photo);
+
+    saveRequest.onsuccess = function saveSuccessHandler() {
+      resolve(saveRequest.result);
+    };
+
+    saveRequest.onerror = function saveErrorHandler() {
+      reject(new Error('Error on save request of indexedDB.'));
+    };
+  });
+  const result = await saveOperation;
+
+  return result;
+}
+
+export async function readPhotoFromDB(photoId) {
+  const search = new Promise(function retrieveRecord(resolve, reject) {
+    const transaction = db.transaction(['photos'], 'readonly');
+
+    transaction.onerror = function readTransactionErrorHandler() {
+      reject(new Error('Error on read transaction of indexedDB.'));
+    };
+
+    const readRequest = transaction.objectStore('photos').get(photoId);
+
+    readRequest.onerror = function readErrorHandler() {
+      reject(new Error('Error on read request of indexedDB.'));
+    };
+
+    readRequest.onsuccess = function readSuccessHandler() {
+      resolve(readRequest.result);
+    };
+  });
+  const photo = await search;
+
+  return photo;
+}
+
+export async function hasPhotoInDB(photoId) {
+  const search = new Promise(function countKeyInDB(resolve, reject) {
+    const transaction = db.transaction(['photos'], 'readonly');
+
+    transaction.onerror = function countTransactionErrorHandler() {
+      reject(new Error('Error on count transaction.'));
+    };
+
+    const countRequest = transaction.objectStore('photos').count(photoId);
+
+    countRequest.onsuccess = function countReadRequestSuccessHandler() {
+      resolve(countRequest.result);
+    };
+
+    countRequest.onerror = function countReadRequestErrorHandler() {
+      reject(new Error('Error on count request.'));
+    };
+  });
+  const count = await search;
+
+  return count;
+}

--- a/src/Components/MarsRovers/Rover/RoverCameras/PulsingThreeDots.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/PulsingThreeDots.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PulsingDot, PulsingDotsContainer } from './styles';
+
+export default function PulsingThreeDots() {
+  return (
+    <PulsingDotsContainer>
+      <PulsingDot />
+      <PulsingDot />
+      <PulsingDot />
+    </PulsingDotsContainer>
+  );
+}

--- a/src/Components/MarsRovers/Rover/RoverCameras/RoverPhotos.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/RoverPhotos.js
@@ -19,6 +19,7 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
 
   useEffect(() => {
     (() => {
+      let isCancelled = true;
       setIsComponentMounted(true);
       setIsFetchingPhotos(true);
       setHasError(false);
@@ -27,7 +28,7 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
           const hasChangedPhotoGallery =
             lastCameraShown !== camera || lastRoverNameShown !== roverName;
           if (activePageNumber !== 1 && hasChangedPhotoGallery) {
-            if (isComponentMounted) {
+            if (isComponentMounted && isCancelled) {
               setActivePageNumber(1);
             }
             return;
@@ -55,11 +56,11 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
           setWholePageIsLoading(false);
           setIsFetchingPhotos(false);
         } catch {
-          if (isComponentMounted) {
+          if (isComponentMounted && isCancelled) {
             setHasError(true);
           }
         } finally {
-          if (isComponentMounted) {
+          if (isComponentMounted && isCancelled) {
             setWholePageIsLoading(false);
             setIsFetchingPhotos(false);
           }
@@ -68,6 +69,7 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
 
       return function onComponentUnmount() {
         setIsComponentMounted(false);
+        isCancelled = false;
       };
     })();
   }, [camera, roverName, setWholePageIsLoading, activePageNumber, isComponentMounted]);

--- a/src/Components/MarsRovers/Rover/RoverCameras/RoverPhotos.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/RoverPhotos.js
@@ -1,17 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import Pagination from 'react-js-pagination';
 import { Global } from '@emotion/core';
-import { v4 as uuidv4 } from 'uuid';
 import { getMostRecentCustomNumberOfPhotosByCamera } from './PhotosDataFetch';
 import updatePaginationBar from './PhotoPagination';
 import { numberOfPhotosPerPage, photosInMemory, numberOfPagesInPagination } from './PhotosConst';
-import {
-  WrapperAlignedToCenter,
-  PaginationStyles,
-  RoverPhotosGrid,
-  RoverPhotoItem,
-} from './styles';
+import { WrapperAlignedToCenter, PaginationStyles, RoverPhotosGrid } from './styles';
 import LoadingSpinner from './LoadingSpinner';
+import ListOfPhotosByPage from './ListOfPhotosByPage';
 
 let lastCameraShown;
 let lastRoverNameShown;
@@ -20,71 +15,75 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
   const [activePageNumber, setActivePageNumber] = useState(1);
   const [isFetchingPhotos, setIsFetchingPhotos] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [isComponentMounted, setIsComponentMounted] = useState(false);
 
   useEffect(() => {
-    setIsFetchingPhotos(true);
-    setHasError(false);
-    (async () => {
-      try {
-        const hasChangedPhotoGallery =
-          lastCameraShown !== camera || lastRoverNameShown !== roverName;
-        if (activePageNumber !== 1 && hasChangedPhotoGallery) {
-          setActivePageNumber(1);
-          return;
+    (() => {
+      setIsComponentMounted(true);
+      setIsFetchingPhotos(true);
+      setHasError(false);
+      (async () => {
+        try {
+          const hasChangedPhotoGallery =
+            lastCameraShown !== camera || lastRoverNameShown !== roverName;
+          if (activePageNumber !== 1 && hasChangedPhotoGallery) {
+            if (isComponentMounted) {
+              setActivePageNumber(1);
+            }
+            return;
+          }
+          const numberOfPhotosToFetch =
+            activePageNumber * numberOfPhotosPerPage -
+            (photosInMemory[roverName][camera] || []).length;
+          if (numberOfPhotosToFetch > 0) {
+            const newSetOfPhotos = await getMostRecentCustomNumberOfPhotosByCamera(
+              camera,
+              numberOfPhotosToFetch,
+              roverName
+            );
+            photosInMemory[roverName][camera] = [
+              ...(photosInMemory[roverName][camera] || []),
+              ...newSetOfPhotos,
+            ];
+          }
+
+          updatePaginationBar(camera, roverName);
+
+          lastCameraShown = camera;
+          lastRoverNameShown = roverName;
+
+          setWholePageIsLoading(false);
+          setIsFetchingPhotos(false);
+        } catch {
+          if (isComponentMounted) {
+            setHasError(true);
+          }
+        } finally {
+          if (isComponentMounted) {
+            setWholePageIsLoading(false);
+            setIsFetchingPhotos(false);
+          }
         }
-        const numberOfPhotosToFetch =
-          activePageNumber * numberOfPhotosPerPage -
-          (photosInMemory[roverName][camera] || []).length;
-        if (numberOfPhotosToFetch > 0) {
-          const newSetOfPhotos = await getMostRecentCustomNumberOfPhotosByCamera(
-            camera,
-            numberOfPhotosToFetch,
-            roverName
-          );
-          photosInMemory[roverName][camera] = [
-            ...(photosInMemory[roverName][camera] || []),
-            ...newSetOfPhotos,
-          ];
-        }
-        updatePaginationBar(camera, roverName);
-        setWholePageIsLoading(false);
-        setIsFetchingPhotos(false);
-        lastCameraShown = camera;
-        lastRoverNameShown = roverName;
-      } catch (error) {
-        setHasError(true);
-        setWholePageIsLoading(false);
-        setIsFetchingPhotos(false);
-      }
+      })();
+
+      return function onComponentUnmount() {
+        setIsComponentMounted(false);
+      };
     })();
-  }, [camera, roverName, setWholePageIsLoading, activePageNumber]);
+  }, [camera, roverName, setWholePageIsLoading, activePageNumber, isComponentMounted]);
 
   const totalItemsCount = numberOfPagesInPagination[roverName][camera] * numberOfPhotosPerPage;
 
-  const firstPhotoIndexToDisplay = (activePageNumber - 1) * numberOfPhotosPerPage;
-  const lastPhotoIndexToDisplay = activePageNumber * numberOfPhotosPerPage;
-  const photosToDisplayInCurrentPage = (photosInMemory[roverName][camera] || []).slice(
-    firstPhotoIndexToDisplay,
-    lastPhotoIndexToDisplay
-  );
-  const listOfRoverPhotoItemsToDisplay = photosToDisplayInCurrentPage.map(
-    function makePhotoItemFromPhotoData(photo) {
-      return (
-        <RoverPhotoItem
-          key={uuidv4()}
-          src={photo.img_src}
-          alt={
-            `Taken by rover ${roverName} from camera ${camera}` +
-            ` on earth date ${photo.earth_date}, which is the` +
-            ` martian sol number ${photo.sol} relative to the rover.`
-          }
-        />
-      );
-    }
+  const listOfRoverPhotoItemsToDisplay = ListOfPhotosByPage(
+    activePageNumber,
+    camera,
+    roverName,
+    numberOfPhotosPerPage,
+    photosInMemory
   );
 
   return (
-    <div>
+    <>
       <Global styles={PaginationStyles} />
       <WrapperAlignedToCenter>
         <Pagination
@@ -104,6 +103,6 @@ export default function RoverPhotos({ camera, roverName, setWholePageIsLoading }
         ) : null}
         {!isFetchingPhotos && !hasError ? listOfRoverPhotoItemsToDisplay : null}
       </RoverPhotosGrid>
-    </div>
+    </>
   );
 }

--- a/src/Components/MarsRovers/Rover/RoverCameras/styles.js
+++ b/src/Components/MarsRovers/Rover/RoverCameras/styles.js
@@ -48,74 +48,76 @@ export const RoverPhotosGrid = Styled.div`
   width: 100%;
   height: auto;
   margin: 0.5rem 0;
-  display: flex;
-  flex-flow: row wrap;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: repeat(2, 47%);
+  justify-content: space-between;
+  row-gap: 1rem;
+
+  @media only screen and (min-width: 500px) {
+    grid-template-columns: repeat(3, 30%);
+    row-gap: 0.8rem;
+  }
+
+  @media only screen and (min-width: 750px) {
+    grid-template-columns: repeat(4, 23%);
+    row-gap: 0.8rem;
+  }
+
+  @media only screen and (min-width: 1000px) {
+    grid-template-columns: repeat(5, 18.8%);
+    row-gap: 0.8rem;
+  }
+
+  @media only screen and (min-width: 1250px) {
+    grid-template-columns: repeat(6, 15.8%);
+    row-gap: 0.8rem;
+  }
 `;
 
-export const RoverPhotoItem = Styled.img`
-  width: 47.5%;
+export const ImageWithHoverToFitGrid = Styled.img`
+  width: 100%;
   min-height: 4rem;
   height: auto;
-  max-height: 47.5vw;
-  margin: 0.5rem 0;
-  margin-right: 5%;
+  max-height: 10rem;
   transition: transform 0.1s ease-in;
 
   &:hover {
     transform: scale(1.075);
   }
+`;
 
-  @media only screen and (max-width: 499px) {
-    &:nth-of-type(2n) {
-      margin-right: 0;
+export const PulsingDotsContainer = Styled.div`
+  margin: 0.5rem;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+  height: 10rem;
+`;
+
+export const PulsingDot = Styled.div`
+  width: 1.0rem;
+  height: 1.0rem;
+  margin: 0.25rem;
+  display: inline-block;
+  background-color: rgb(255,108,67);
+  border-radius: 50%;
+  animation: sizeOscilation 0.9s infinite linear;
+
+  &:first-of-type {
+    animation-delay: -0.2s;
+  }
+
+  &:last-of-type {
+    animation-delay: 0.2s;
+  }
+
+  @keyframes sizeOscilation {
+    0%, 100% {
+      transform: scale(0);
     }
-  }
-
-  @media only screen and (min-width: 500px) {
-    width: calc(90%/3);
-    max-height: calc(90vw/3);
-  }
-
-  @media only screen and (min-width: 500px) and (max-width: 749px) {
-    &:nth-of-type(3n) {
-      margin-right: 0;
-    }
-  }
-
-  @media only screen and (min-width: 750px) {
-    width: calc(92.5%/4);
-    max-height: calc(92.5vw/4);
-    margin-right: 2.5%;
-  }
-
-  @media only screen and (min-width: 750px) and (max-width: 999px) {
-    &:nth-of-type(4n) {
-      margin-right: 0;
-    }
-  }
-
-  @media only screen and (min-width: 1000px) {
-    width: calc(94%/5);
-    max-height: calc(94vw/5);
-    margin-right: 1.5%;
-  }
-
-  @media only screen and (min-width: 1000px) and (max-width: 1249px) {
-    &:nth-of-type(5n) {
-      margin-right: 0;
-    }
-  }
-
-  @media only screen and (min-width: 1250px) {
-    width: calc(95%/6);
-    max-height: calc(95vw/6);
-    margin-right: 1%;
-  }
-
-  @media only screen and (min-width: 1250px) {
-    &:nth-of-type(6n) {
-      margin-right: 0;
+    30% {
+      transform: scale(1);
     }
   }
 `;
@@ -149,6 +151,7 @@ export const Spinner = Styled.div`
   border-top-color: rgb(207, 49, 29);
   width: 3rem;
   height: 3rem;
+  margin: 10rem 0 20rem 0;
   border-radius: 50%;
   animation: spinner 0.9s infinite linear;
 

--- a/src/Pages/MarsRovers/index.jsx
+++ b/src/Pages/MarsRovers/index.jsx
@@ -31,7 +31,6 @@ export default class MarsRoversIndex extends Component {
         3000
       ).then(
         (rovers) => {
-          console.log('Rovers', rovers);
           rovers.forEach(savePhotosManifest);
           if (rovers.some((rover) => rover.photo_manifest === undefined))
             this.setState({ error: true, isLoading: false });
@@ -83,28 +82,19 @@ MarsRoversIndex.defaultProps = {
     opportunity: {},
   },
 };
+
+const marsRoversIndexPropType = PropTypes.shape({
+  name: PropTypes.string,
+  landing_date: PropTypes.string,
+  launch_date: PropTypes.string,
+  max_date: PropTypes.string,
+  max_sol: PropTypes.number,
+});
+
 MarsRoversIndex.propTypes = {
   manifest: PropTypes.shape({
-    curiosity: PropTypes.shape({
-      name: PropTypes.string,
-      landing_date: PropTypes.string,
-      launch_date: PropTypes.string,
-      max_date: PropTypes.string,
-      max_sol: PropTypes.number,
-    }),
-    spirit: PropTypes.shape({
-      name: PropTypes.string,
-      landing_date: PropTypes.string,
-      launch_date: PropTypes.string,
-      max_date: PropTypes.string,
-      max_sol: PropTypes.number,
-    }),
-    opportunity: PropTypes.shape({
-      name: PropTypes.string,
-      landing_date: PropTypes.string,
-      launch_date: PropTypes.string,
-      max_date: PropTypes.string,
-      max_sol: PropTypes.number,
-    }),
+    curiosity: marsRoversIndexPropType,
+    spirit: marsRoversIndexPropType,
+    opportunity: marsRoversIndexPropType,
   }),
 };


### PR DESCRIPTION
**Task**

This PR adds `IndexDB` to scale the performance of the Mars photo fetch from NASA API. In this way, the calls are reduced to the API to not reach the quota limit and have pictures loaded faster.

**Changes**

Added `indexedDB` to save downloaded photos in the browser memory and to make fewer requests, added `PhotoItem` component to handle the logic of each photo, edited styles to prevent screen resizing when the `LoadingSpinner` component appears, added `isComponentMounted` to prevent async state updates when the component is unmounted

